### PR TITLE
signal: always close response body

### DIFF
--- a/signal/pull_report.go
+++ b/signal/pull_report.go
@@ -30,13 +30,13 @@ func pullHealthReport(healthURL string, endpoint string) (hr *HealthReport, err 
 		log.Error("Error handling response from ", url, ": ", err)
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Error(err)
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if err := json.Unmarshal(body, &hr); err != nil {
 		log.Error("Error unmarshaling JSON body: ", err)


### PR DESCRIPTION
The response body should be closed even if there was an error reading from it.