### PR TITLE
Test Flag to STDOUT

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -84,7 +84,7 @@ func (c *Config) getClusterID() error {
 		return err
 	}
 	c.ClusterID = strings.TrimSpace(string(fileByte))
-	log.Infof("Detected Cluster ID: %s", c.ClusterID)
+	log.Debugf("Detected Cluster ID: %s", c.ClusterID)
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	// Optional CLI Flags
 	FlagVersion bool
 	FlagVerbose bool
-	TestURL     string
+	FlagTest    bool
 	Enabled     string `json:"enabled"`
 
 	// Extra headers for all reporter{}'s
@@ -75,7 +75,7 @@ func (c *Config) setFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.DCOSClusterIDPath, "cluster-id-path", c.DCOSClusterIDPath, "Override path to DCOS anonymous ID.")
 	fs.StringVar(&c.SignalServiceConfigPath, "c", c.SignalServiceConfigPath, "Path to dcos-signal-service.conf.")
 	fs.StringVar(&c.SegmentKey, "segment-key", c.SegmentKey, "Key for segmentIO.")
-	fs.StringVar(&c.TestURL, "test-url", c.TestURL, "Override default test URL")
+	fs.BoolVar(&c.FlagTest, "test", c.FlagTest, "Dump the data sent to segment to stdout.")
 }
 
 func (c *Config) getClusterID() error {
@@ -130,6 +130,7 @@ func (c *Config) tryLoadingCert() error {
 	return nil
 }
 
+// ParseArgsReturnConfig does exactly that
 func ParseArgsReturnConfig(args []string) (Config, []error) {
 	errAry := []error{}
 	c := DefaultConfig()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,14 +40,14 @@ func TestFlagParsing(t *testing.T) {
 			"-c", tempConfig.Name()})
 
 		testConfig, testConfigErr = ParseArgsReturnConfig([]string{
-			"-test-url", "http://foo.com",
+			"-test",
 			"-cluster-id-path", tempAnonJson.Name(),
 			"-c", tempConfig.Name()})
 	)
 
 	// -test
-	if testConfig.TestURL != "http://foo.com" {
-		t.Error("Expected test flag to be true, got ", testConfig.TestURL)
+	if !testConfig.FlagTest {
+		t.Error("Expected test flag to be true, got ", testConfig.FlagTest)
 	}
 	if testConfigErr != nil {
 		t.Error("Expected test error to be nil, got ", testConfigErr)

--- a/signal/signal_test.go
+++ b/signal/signal_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/dcos/dcos-signal/config"
@@ -144,8 +143,7 @@ func mockRouter() *mux.Router {
 }
 
 func TestExecuteTester(t *testing.T) {
-	url, _ := url.Parse(server.URL)
-	testURL := "http://" + url.Host + "/tester"
+	test := true
 
 	var (
 		mockTrack = &analytics.Track{}
@@ -153,7 +151,7 @@ func TestExecuteTester(t *testing.T) {
 			"foo": mockTrack,
 		}
 		mockConfig = config.Config{
-			TestURL: testURL,
+			FlagTest: test,
 		}
 	)
 


### PR DESCRIPTION
Refactor the test flag to dump to stdout so we can support the new version of integration tests which execute directly within a cluster.

CC @mellenburg @spahl @alberts 

Request review @darkonie 