### PR TITLE
Add gen_platform config param

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	// DCOS-Specific Data
 	DCOSVersion       string
 	DCOSVariant       string
+	GenPlatform       string `json:"gen_platform"`
 	GenProvider       string `json:"gen_provider"`
 	DCOSClusterIDPath string
 
@@ -151,6 +152,7 @@ func ParseArgsReturnConfig(args []string) (Config, []error) {
 
 	// Get standard and extra JSON config off disk
 	if err := c.getExternalConfig(); err != nil {
+		c.GenPlatform = err.Error()
 		c.GenProvider = err.Error()
 		c.CustomerKey = err.Error()
 		errAry = append(errAry, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,7 +93,8 @@ func TestGetExternalConfig(t *testing.T) {
 	noEntConfig := []byte(`
 {
 "customer_key": "",
-"gen_provider": "onprem"	
+"gen_platform": "vagrant-virtualbox",
+"gen_provider": "onprem"
 }`)
 	noEntFile, _ := ioutil.TempFile(os.TempDir(), "")
 
@@ -109,6 +110,10 @@ func TestGetExternalConfig(t *testing.T) {
 
 	if noEntC.CustomerKey != "" {
 		t.Error("Expected customer ID to be empty, got ", noEntC.CustomerKey)
+	}
+
+	if noEntC.GenPlatform != "vagrant-virtualbox" {
+		t.Error("Expected vagrant-virtualbox, got ", noEntC.GenPlatform)
 	}
 
 	if noEntC.GenProvider != "onprem" {

--- a/signal/cosmos.go
+++ b/signal/cosmos.go
@@ -86,6 +86,7 @@ func (c *Cosmos) setTrack(config config.Config) error {
 		"environmentVersion": config.DCOSVersion,
 		"clusterId":          config.ClusterID,
 		"variant":            config.DCOSVariant,
+		"platform":           config.GenPlatform,
 		"provider":           config.GenProvider,
 	}
 

--- a/signal/cosmos_test.go
+++ b/signal/cosmos_test.go
@@ -20,6 +20,7 @@ func TestCosmosTrack(t *testing.T) {
 	c.CustomerKey = "12345"
 	c.ClusterID = "anon"
 	c.DCOSVersion = "test_version"
+	c.GenPlatform = "test_platform"
 	c.GenProvider = "test_provider"
 	c.DCOSVariant = "test_variant"
 
@@ -60,8 +61,12 @@ func TestCosmosTrack(t *testing.T) {
 		t.Error("Expected customerKey to be 12345, got ", actualSegmentTrack.Properties["customerKey"])
 	}
 
+	if actualSegmentTrack.Properties["platform"] != "test_platform" {
+		t.Error("Expected platform 'test_platform', got ", actualSegmentTrack.Properties["platform"])
+	}
+
 	if actualSegmentTrack.Properties["provider"] != "test_provider" {
-		t.Error("Expected provder 'test_provider', got ", actualSegmentTrack.Properties["provider"])
+		t.Error("Expected provider 'test_provider', got ", actualSegmentTrack.Properties["provider"])
 	}
 
 	if actualSegmentTrack.Properties["variant"] != "test_variant" {

--- a/signal/diagnostics.go
+++ b/signal/diagnostics.go
@@ -98,6 +98,7 @@ func (d *Diagnostics) setTrack(c config.Config) error {
 		"environmentVersion": c.DCOSVersion,
 		"clusterId":          c.ClusterID,
 		"variant":            c.DCOSVariant,
+		"platform":           c.GenPlatform,
 		"provider":           c.GenProvider,
 	}
 

--- a/signal/diagnostics_test.go
+++ b/signal/diagnostics_test.go
@@ -22,6 +22,7 @@ func TestDiagnosticsTrack(t *testing.T) {
 	c.CustomerKey = "12345"
 	c.ClusterID = "anon"
 	c.DCOSVersion = "test_version"
+	c.GenPlatform = "test_platform"
 	c.GenProvider = "test_provider"
 	c.DCOSVariant = "test_variant"
 
@@ -39,8 +40,8 @@ func TestDiagnosticsTrack(t *testing.T) {
 		t.Error("Expected no errors running diagnostics.SetTrack(), got ", setupErr)
 	}
 
-	if len(actualSegmentTrack.Properties) != 10 {
-		t.Error("Expected 10 properties, got ", len(actualSegmentTrack.Properties))
+	if len(actualSegmentTrack.Properties) != 11 {
+		t.Error("Expected 11 properties, got ", len(actualSegmentTrack.Properties))
 	}
 
 	if actualSegmentTrack.Event != "health" {
@@ -67,8 +68,12 @@ func TestDiagnosticsTrack(t *testing.T) {
 		t.Error("Expected customerKey to be 12345, got ", actualSegmentTrack.Properties["customerKey"])
 	}
 
+	if actualSegmentTrack.Properties["platform"] != "test_platform" {
+		t.Error("Expected platform 'test_platform', got ", actualSegmentTrack.Properties["platform"])
+	}
+
 	if actualSegmentTrack.Properties["provider"] != "test_provider" {
-		t.Error("Expected provder 'test_provider', got ", actualSegmentTrack.Properties["provider"])
+		t.Error("Expected provider 'test_provider', got ", actualSegmentTrack.Properties["provider"])
 	}
 
 	if actualSegmentTrack.Properties["variant"] != "test_variant" {

--- a/signal/mesos.go
+++ b/signal/mesos.go
@@ -93,6 +93,7 @@ func (d *Mesos) setTrack(c config.Config) error {
 		"environmentVersion": c.DCOSVersion,
 		"clusterId":          c.ClusterID,
 		"variant":            c.DCOSVariant,
+		"platform":           c.GenPlatform,
 		"provider":           c.GenProvider,
 		"frameworks":         d.Report.Frameworks,
 		"cpu_total":          d.Report.CPUTotal,

--- a/signal/mesos_test.go
+++ b/signal/mesos_test.go
@@ -22,6 +22,7 @@ func testMesosTrack(t *testing.T) {
 	c.CustomerKey = "12345"
 	c.ClusterID = "anon"
 	c.DCOSVersion = "test_version"
+	c.GenPlatform = "test_platform"
 	c.GenProvider = "test_provider"
 	c.DCOSVariant = "test_variant"
 
@@ -60,6 +61,10 @@ func testMesosTrack(t *testing.T) {
 
 	if actualSegmentTrack.Properties["customerKey"] != "12345" {
 		t.Error("Expected customerKey to be 12345, got ", actualSegmentTrack.Properties["customerKey"])
+	}
+
+	if actualSegmentTrack.Properties["platform"] != "test_platform" {
+		t.Error("Expected provder 'test_platform', got ", actualSegmentTrack.Properties["platform"])
 	}
 
 	if actualSegmentTrack.Properties["provider"] != "test_provider" {


### PR DESCRIPTION
`platform` indicates WHAT platform DC/OS is deployed on, rather than HOW the install artifacts were generated (`provider`)