### PR TITLE
fix false positive failed units

### DIFF
--- a/signal/diagnostics.go
+++ b/signal/diagnostics.go
@@ -109,9 +109,15 @@ func (d *Diagnostics) setTrack(c config.Config) error {
 	for _, unit := range d.Report.Units {
 		totalUnits := len(unit.Nodes)
 		totalUnhealthyUnits := 0
+
 		for _, node := range unit.Nodes {
-			if node.Health != 0 {
-				log.Debugf("UNHEALTHY NODE: %s", node.IP)
+			errorLog, ok := node.Output[unit.UnitName]
+			if !ok {
+				log.Errorf("unit %s is not in node output", unit.UnitName)
+			}
+
+			if errorLog != "" {
+				log.Debugf("UNHEALTHY NODE: %s, journald log: %s", node.IP, errorLog)
 				totalUnhealthyUnits++
 			} else {
 				for _, nodeUnit := range node.Units {

--- a/signal/diagnostics_test.go
+++ b/signal/diagnostics_test.go
@@ -96,7 +96,7 @@ func TestDiagnosticsTrack(t *testing.T) {
 		t.Error("Expected key health-unit-foo-unit-2-unhealthy to exist, got ", ok)
 	}
 
-	if val, _ := actualSegmentTrack.Properties["health-unit-foo-unit-2-unhealthy"]; val != 1 {
+	if val, _ := actualSegmentTrack.Properties["health-unit-foo-unit-2-unhealthy"]; val != 2 {
 		t.Error("Expected key health-unit-foo-unit-2-unhealthy to be 1, got ", val)
 	}
 
@@ -111,7 +111,7 @@ func TestDiagnosticsTrack(t *testing.T) {
 		t.Error("Expected key health-unit-foo-unit-1-unhealthy to exist, got ", ok)
 	}
 
-	if val, _ := actualSegmentTrack.Properties["health-unit-foo-unit-1-unhealthy"]; val != 1 {
+	if val, _ := actualSegmentTrack.Properties["health-unit-foo-unit-1-unhealthy"]; val != 0 {
 		t.Error("Expected key health-unit-foo-unit-1-unhealthy to be 1, got ", val)
 	}
 }

--- a/signal/diagnostics_test.go
+++ b/signal/diagnostics_test.go
@@ -97,7 +97,7 @@ func TestDiagnosticsTrack(t *testing.T) {
 	}
 
 	if val, _ := actualSegmentTrack.Properties["health-unit-foo-unit-2-unhealthy"]; val != 2 {
-		t.Error("Expected key health-unit-foo-unit-2-unhealthy to be 1, got ", val)
+		t.Error("Expected key health-unit-foo-unit-2-unhealthy to be 2, got ", val)
 	}
 
 	if _, ok := actualSegmentTrack.Properties["health-unit-foo-unit-1-total"]; !ok {
@@ -112,6 +112,6 @@ func TestDiagnosticsTrack(t *testing.T) {
 	}
 
 	if val, _ := actualSegmentTrack.Properties["health-unit-foo-unit-1-unhealthy"]; val != 0 {
-		t.Error("Expected key health-unit-foo-unit-1-unhealthy to be 1, got ", val)
+		t.Error("Expected key health-unit-foo-unit-1-unhealthy to be 0, got ", val)
 	}
 }

--- a/signal/signal_test.go
+++ b/signal/signal_test.go
@@ -19,7 +19,7 @@ var mockNodes = []*Node{
 		Host:   "foo.master",
 		Health: 0,
 		Output: map[string]string{
-			"foo-unit.2": "",
+			"foo-unit.2": "Something is broken!!",
 			"foo-unit.1": "",
 		},
 		Units: nil,
@@ -41,7 +41,7 @@ var mockUnits = map[string]*Unit{
 	"10.0.0.1": {
 		UnitName: "foo-unit.1",
 		Nodes:    mockNodes,
-		Health:   1,
+		Health:   0,
 		Title:    "Foo Test 1",
 	},
 	"10.0.0.2": {


### PR DESCRIPTION
dcos-diagnostics provides 2 types of health reports:
1. Component health aka systemd unit health.
2. Node health. A node is considered to be unhealthy if at least 1 component
    is unhealthy.

if one component is unhealthy the node becomes unhealthy, and dcos-signal
thinks all units living on this node are unhealthy too. PR fixes this bug.

[DCOS-20017](https://jira.mesosphere.com/browse/DCOS-20017)