### PR TITLE
Fixed deadlock when processing workers

### DIFF
--- a/signal/reporters.go
+++ b/signal/reporters.go
@@ -4,7 +4,7 @@ import (
 	"github.com/dcos/dcos-signal/config"
 )
 
-func makeReporters(c config.Config) (chan Reporter, error) {
+func makeReporters(c config.Config) ([]Reporter, error) {
 
 	var reporters = []Reporter{
 		&Diagnostics{
@@ -34,11 +34,9 @@ func makeReporters(c config.Config) (chan Reporter, error) {
 		},
 	}
 
-	reportChan := make(chan Reporter, len(reporters))
 	for _, r := range reporters {
 		r.addHeaders(c.ExtraHeaders)
-		reportChan <- r
 	}
 
-	return reportChan, nil
+	return reporters, nil
 }

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -52,7 +52,10 @@ func executeRunner(c config.Config) error {
 		return errors.New("unable to get reporters")
 	}
 
-	runner(reporters, c)
+	err = runner(reporters, c)
+	if err != nil {
+		return fmt.Errorf("Error gathering data: %s", err)
+	}
 
 	tester := make(map[string]*analytics.Track)
 

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -67,7 +67,8 @@ func executeRunner(c config.Config) error {
 	tester := make(map[string]*analytics.Track)
 
 	processed := 1
-	for r := range done {
+	for processed <= workers {
+		r := <-done
 		for _, err := range r.getError() {
 			log.Errorf("%s: %s", r.getName(), err)
 		}


### PR DESCRIPTION
2615bc7f7d524858be0c5ed603fb24e7d35d9292 introduced a deadlock since
the `done` channel is never closed and the loop just sits there
waiting for more data from the channel.