### PR TITLE
[DCOS-57061] Add enterprise functionality 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 dcos-signal
 ./signal_*
-config/enterprise.go*
 scripts/mocklicensing/mocklicensing

--- a/config/config.go
+++ b/config/config.go
@@ -18,11 +18,11 @@ import (
 )
 
 type DCOSVariant struct {
-	name string
+	Name string
 }
 
 func (v DCOSVariant) String() string {
-	return v.name
+	return v.Name
 }
 
 func (v *DCOSVariant) Set(variant string) error {
@@ -31,7 +31,7 @@ func (v *DCOSVariant) Set(variant string) error {
 	} else if variant != "open" {
 		return fmt.Errorf("unknown variant '%s'. Only 'open' or 'enterprise' are allowed", variant)
 	}
-	v.name = variant
+	v.Name = variant
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -224,7 +224,7 @@ func ParseArgsReturnConfig(args []string) (Config, []error) {
 
 	// Not all clusters will have a license, including open source clusters.
 	if err := c.getLicenseID(); err != nil {
-		log.Errorf("Error getting LicenseID. Got error: %v", err)
+		log.Errorf("error getting LicenseID. Got error: %v", err)
 	}
 
 	// Get the cluster-id generate by ZK consensus

--- a/config/enterprise.go
+++ b/config/enterprise.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/dgrijalva/jwt-go"
+)
+
+func initEnterprise() {
+	token, err := generateJWTToken()
+	if err != nil {
+		log.Fatalf("Unable to generate JWT token: %s", err)
+		os.Exit(1)
+	}
+
+	defaultConfig.DCOSVariant = DCOSVariant{"enterprise"}
+	defaultConfig.ExtraHeaders["Authorization"] = fmt.Sprintf("token=%s", token)
+}
+
+func generateJWTToken() (string, error) {
+	securityConfig := struct {
+		UID            string `json:"uid"`
+		PrivateKey     string `json:"private_key"`
+		LoginEndpoint  string `json:"login_endpoint"`
+		JWTToken       string
+		SecretJSONPath string
+	}{
+		SecretJSONPath: "/run/dcos/etc/signal-service/service_account.json",
+	}
+	// Load the secret file if it exists
+	secretJSON, loadErr := ioutil.ReadFile(securityConfig.SecretJSONPath)
+	if loadErr != nil {
+		log.Warn("Service account not detected, continuing with out secure requests.")
+		return "", nil
+	}
+
+	if jsonErr := json.Unmarshal(secretJSON, &securityConfig); jsonErr != nil {
+		return "", jsonErr
+	}
+
+	if securityConfig.UID == "" || securityConfig.PrivateKey == "" || securityConfig.LoginEndpoint == "" {
+		return "", errors.New("UID, private key or login endpoint can not be empty.")
+	}
+	log.Debug("Generating JWT token...")
+	token := jwt.New(jwt.SigningMethodRS256)
+	token.Claims["uid"] = securityConfig.UID
+	token.Claims["exp"] = time.Now().Add(time.Hour).Unix()
+	tokenStr, err := token.SignedString([]byte(securityConfig.PrivateKey))
+	if err != nil {
+		return "", err
+	}
+
+	client := http.Client{
+		Timeout: time.Duration(5 * time.Second),
+	}
+
+	authReq := struct {
+		UID   string `json:"uid"`
+		Token string `json:"token,omitempty"`
+	}{
+		UID:   securityConfig.UID,
+		Token: tokenStr,
+	}
+
+	b, err := json.Marshal(authReq)
+	if err != nil {
+		return "", err
+	}
+
+	authBody := bytes.NewBuffer(b)
+	req, err := http.NewRequest("POST", securityConfig.LoginEndpoint, authBody)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Content-type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Failed to auth with Bouncer,  status code: %d", resp.StatusCode)
+	}
+
+	var authResp struct {
+		Token string `json:"token"`
+	}
+
+	if err = json.NewDecoder(resp.Body).Decode(&authResp); err != nil {
+		return "", err
+	}
+
+	log.Debugf("Successfully retrieved JWT token: %s", authResp.Token)
+	return authResp.Token, nil
+}

--- a/config/enterprise.go
+++ b/config/enterprise.go
@@ -88,7 +88,7 @@ func generateJWTToken() (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Failed to auth with Bouncer,  status code: %d", resp.StatusCode)
+		return "", fmt.Errorf("failed to auth with Bouncer,  status code: %d", resp.StatusCode)
 	}
 
 	var authResp struct {

--- a/signal/cosmos_test.go
+++ b/signal/cosmos_test.go
@@ -27,7 +27,7 @@ func TestCosmosTrack(t *testing.T) {
 	c.DCOSVersion = "test_version"
 	c.GenPlatform = "test_platform"
 	c.GenProvider = "test_provider"
-	c.DCOSVariant = "test_variant"
+	c.DCOSVariant = config.DCOSVariant{"test_variant"}
 
 	for _, endpoint := range testCosmos.Endpoints {
 		pullErr := PullReport(endpoint, &testCosmos, c)
@@ -78,7 +78,7 @@ func TestCosmosTrack(t *testing.T) {
 		t.Error("Expected provider 'test_provider', got ", actualSegmentTrack.Properties["provider"])
 	}
 
-	if actualSegmentTrack.Properties["variant"] != "test_variant" {
+	if actualSegmentTrack.Properties["variant"].(config.DCOSVariant).Name != "test_variant" {
 		t.Error("Expected variant 'test_variant', got ", actualSegmentTrack.Properties["variant"])
 	}
 

--- a/signal/diagnostics_test.go
+++ b/signal/diagnostics_test.go
@@ -27,7 +27,7 @@ func TestDiagnosticsTrack(t *testing.T) {
 	c.DCOSVersion = "test_version"
 	c.GenPlatform = "test_platform"
 	c.GenProvider = "test_provider"
-	c.DCOSVariant = "test_variant"
+	c.DCOSVariant = config.DCOSVariant{"test_variant"}
 
 	for _, e := range testDiag.Endpoints {
 		pullErr := PullReport(e, &testDiag, c)
@@ -83,7 +83,7 @@ func TestDiagnosticsTrack(t *testing.T) {
 		t.Error("Expected provider 'test_provider', got ", actualSegmentTrack.Properties["provider"])
 	}
 
-	if actualSegmentTrack.Properties["variant"] != "test_variant" {
+	if actualSegmentTrack.Properties["variant"].(config.DCOSVariant).Name != "test_variant" {
 		t.Error("Expected variant 'test_variant', got ", actualSegmentTrack.Properties["variant"])
 	}
 

--- a/signal/mesos_test.go
+++ b/signal/mesos_test.go
@@ -27,7 +27,7 @@ func testMesosTrack(t *testing.T) {
 	c.DCOSVersion = "test_version"
 	c.GenPlatform = "test_platform"
 	c.GenProvider = "test_provider"
-	c.DCOSVariant = "test_variant"
+	c.DCOSVariant = config.DCOSVariant{"test_variant"}
 
 	for _, e := range testMesos.Endpoints {
 		pullErr := PullReport(e, &testMesos, c)

--- a/signal/reporter.go
+++ b/signal/reporter.go
@@ -88,7 +88,7 @@ func PullReport(endpoint string, r Reporter, c config.Config) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Response %s %s: %s", resp.Proto, endpoint, resp.Status)
+		return fmt.Errorf("response %s %s: %s", resp.Proto, endpoint, resp.Status)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -19,17 +19,17 @@ var (
 func runner(reporters []Reporter, c config.Config) error {
 	for _, r := range reporters {
 		if len(r.getEndpoints()) == 0 {
-			return fmt.Errorf("Reporter %s has no endpoints", r.getName())
+			return fmt.Errorf("reporter %s has no endpoints", r.getName())
 		}
 		for _, endpoint := range r.getEndpoints() {
 			log.Debugf("Processing %s endpoint %s", r.getName(), endpoint)
 			if err := PullReport(endpoint, r, c); err != nil {
-				log.Errorf("Error setting track for %s: %s", r.getName(), err.Error())
+				log.Errorf("error setting track for %s: %s", r.getName(), err.Error())
 				r.appendError(err.Error())
 			}
 
 			if err := r.setTrack(c); err != nil {
-				log.Errorf("Error setting track for %s: %s", r.getName(), err.Error())
+				log.Errorf("error setting track for %s: %s", r.getName(), err.Error())
 				r.appendError(err.Error())
 			}
 		}
@@ -54,7 +54,7 @@ func executeRunner(c config.Config) error {
 
 	err = runner(reporters, c)
 	if err != nil {
-		return fmt.Errorf("Error gathering data: %s", err)
+		return fmt.Errorf("error gathering data: %s", err)
 	}
 
 	tester := make(map[string]*analytics.Track)
@@ -73,7 +73,7 @@ func executeRunner(c config.Config) error {
 			}
 		} else {
 			if err := r.sendTrack(c); err != nil {
-				log.Errorf("Error tracking %s: %s", r.getName(), err)
+				log.Errorf("error tracking %s: %s", r.getName(), err)
 			}
 		}
 		log.Warnf("processed %d", processed)

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -72,7 +72,9 @@ func executeRunner(c config.Config) error {
 				log.Errorf("%s: %s", r.getName(), err)
 			}
 		} else {
-			_ = r.sendTrack(c)
+			if err := r.sendTrack(c); err != nil {
+				log.Errorf("Error tracking %s: %s", r.getName(), err)
+			}
 		}
 		log.Warnf("processed %d", processed)
 		processed++


### PR DESCRIPTION
The new CLI flag `-dcos-variant` lets you set the DC/OS variant that signal is running on. This way, you can use dcos-signal on Enterprise clusters now as well.