### PR TITLE
[DCOS-57061] properly marshal DCOSVariant

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,10 @@ type DCOSVariant struct {
 	Name string
 }
 
+func (v DCOSVariant) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", v.Name)), nil
+}
+
 func (v DCOSVariant) String() string {
 	return v.Name
 }


### PR DESCRIPTION
It must be marshalled into `"open"` or `"enterprise"` and not into an
object with the `Name` property.